### PR TITLE
boost-zstd: Add Boost include dirs

### DIFF
--- a/3rdparty/boost-zstd/CMakeLists.txt
+++ b/3rdparty/boost-zstd/CMakeLists.txt
@@ -1,4 +1,7 @@
-include_directories(${ZSTD_INCLUDE_DIR})
+include_directories(
+    ${ZSTD_INCLUDE_DIR}
+    ${Boost_INCLUDE_DIRS}
+)
 
 add_library(boost-zstd STATIC zstd.cpp)
 target_link_libraries(boost-zstd LINK_PUBLIC


### PR DESCRIPTION
Without this patch, the Boost includes cannot be found.
Tested on RHEL7 with EPEL where Boost is located in /usr/include/boost169.